### PR TITLE
fix: publish to Redis unconditionally, drop the presence-bit gate (SS-12389)

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -25,11 +25,6 @@ Redis.prototype.name = 'Redis';
 Redis.prototype.publish = function func(msg, callback) {
   const self = this;
   const str = JSON.stringify(msg);
-  let eventType = self.options.eventType;
-
-  if (msg.eventType) {
-    eventType = msg.eventType;
-  }
 
   const bus = msg.bus;
   if (_.isNil(bus)) {
@@ -37,14 +32,14 @@ Redis.prototype.publish = function func(msg, callback) {
     return callback();
   }
 
-  return self.redisClient.GETBIT(msg.clientId, 0, (err, result) => {
-    if (result === 0) {
-      //console.info('Transporter: No clients connected, not publishing message');
-      return callback();
-    }
-    //console.log(`Transporter: Pub to ${eventType} stream ${self.name} - ${str}`);
-    return self.redisClient.publish(bus, str, () => callback());
-  });
+  //
+  // Publish unconditionally. This used to be gated on GETBIT <clientId> 0, a
+  // presence flag owned by the Cayenne-Streaming service. That service was
+  // retired and nothing set the bit any more, so publishes were silently
+  // dropped for most clients. A PUBLISH to a channel with no subscribers is
+  // cheap, and the higher volume data-changed stream has always been ungated.
+  //
+  return self.redisClient.publish(bus, str, () => callback());
 };
 
 exports.Redis = Redis;


### PR DESCRIPTION
## Problem

The Redis transport only published when `GETBIT <clientId> 0` returned `1`:

```js
return self.redisClient.GETBIT(msg.clientId, 0, (err, result) => {
  if (result === 0) {
    return callback();
  }
  return self.redisClient.publish(bus, str, () => callback());
});
```

That bit was a presence flag owned by **Cayenne-Streaming**, which was retired when tina-api became the socket.io streaming server (SS-12044). Nothing has set it since, so publishes were silently dropped for every client whose bit was not left stale at `1`.

Because a single `Transporter.publish()` fans out to Redis **and** RabbitMQ, and only the Redis leg was gated, the symptom was oddly asymmetric: consumers kept receiving alerts over RabbitMQ and writing them to the database, while browsers never got the realtime `alert-state-changed` event. Reloading the page showed the correct state, which masked the bug.

## Evidence

Measured on staging over one identical 6-minute window:

| Cayenne client | RabbitMQ | Redis | presence bit |
|---|---|---|---|
| `7a9334b0-7069-11f0-9515-0b2963dafdba` | 18 | 18 | `1` (stale) |
| `af153e10-d14c-11f0-a773-570095349833` | 1 | 1 | `1` (stale) |
| `aa61dcd0-5f62-11f1-bb8c-33fc1eff9690` | 7 | **0** | `0` (key missing) |
| `d73a85c0-6b5e-11f0-9515-0b2963dafdba` | 6 | **0** | `0` |

Setting the bit for the two broken clients made their alerts appear on Redis immediately.

## Change

Publish unconditionally. A `PUBLISH` to a channel with no subscribers is cheap, and starbase's `Firehose` transport has always published the far higher volume `data-changed` stream with no such gate — on staging that is ~12,900 messages per 4 minutes versus roughly 7 alerts, so the added load is noise.

Also removes the now-dead `eventType` local, which was only referenced from commented-out logging.

## Base branch

Branched from `7b4362a`, **not** `master`. Master bumped `redis` to `^4.6.5` while this file still uses the v2 callback API and flat `{host, port, password}` options, both removed in node-redis v4 — so master's Redis transport does not work as written. `7b4362a` is the SHA that executor and starbase actually pin and run.

The PR diff is therefore just the `lib/redis.js` change. Note that merging this does **not** fix master's redis v4 incompatibility, which remains outstanding.

## Consumers

- `executor` — pins this by git SHA; companion PR bumps it
- `starbase` — pins transporter but registers its own `Firehose` transport, never `lib/redis.js`; unaffected
- `rabbit-transporter`, `pubsub-transporter` — depend on this package but only use the `Transport` base class; unaffected

The same gate exists independently in Go in `gollux/pkg/pub/transporter.go` and is removed in a separate PR.

## Testing

This repo has no test suite (`"test": "echo \"Error: no test specified\" && exit 1"`). Verified by syntax check plus the staging measurements above.